### PR TITLE
Fix async thunk calls

### DIFF
--- a/src/features/post/postSlice.js
+++ b/src/features/post/postSlice.js
@@ -10,13 +10,13 @@ export const postSlice = createSlice({
   },
   extraReducers: {
     [GetPosts.fulfilled]: (state, action) => {
-      state.posts = action.payload.data;
+      state.posts = action.payload;
     },
     [GetPosts.rejected]: (state, action) => {
       state.posts = [];
     },
     [CreatePost.fulfilled]: (state, action) => {
-      state.posts.unshift(action.payload.data);
+      state.posts.unshift(action.payload);
     },
   },
 });

--- a/src/services.js
+++ b/src/services.js
@@ -5,15 +5,15 @@ const BASE_URL = "http://localhost:5050";
 
 export const GetPosts = createAsyncThunk(
   "post/getPosts",
-  async () => await axios.get(`${BASE_URL}/posts`)
+  async () => await (await axios.get(`${BASE_URL}/posts`)).data
 );
 
 export const CreatePost = createAsyncThunk(
   "post/createPost",
-  async (post) => await axios.post(`${BASE_URL}/post`, post)
+  async (post) => await (await axios.post(`${BASE_URL}/post`, post)).data
 );
 
 export const DeletePost = createAsyncThunk(
   "post/deletePost",
-  async (post) => await axios.post(`${BASE_URL}/post`, post)
+  async (post) => await axios.post(`${BASE_URL}/post`, post).data
 );

--- a/src/services.js
+++ b/src/services.js
@@ -5,7 +5,7 @@ const BASE_URL = "http://localhost:5050";
 
 export const GetPosts = createAsyncThunk(
   "post/getPosts",
-  async () => await (await axios.get(`${BASE_URL}/posts`)).data
+  async () => await await (await axios.get(`${BASE_URL}/posts`)).data
 );
 
 export const CreatePost = createAsyncThunk(
@@ -15,5 +15,5 @@ export const CreatePost = createAsyncThunk(
 
 export const DeletePost = createAsyncThunk(
   "post/deletePost",
-  async (post) => await axios.post(`${BASE_URL}/post`, post).data
+  async (post) => await (await axios.post(`${BASE_URL}/post`, post)).data
 );


### PR DESCRIPTION
Hi,

I was getting a small issue with the async thunk calls when I followed your "Simplifying Redux with Redux Toolkit" article, while it functioned there was a javascript console error saying "non-serializable value was detected in an action". The same as the error highlighted here:

https://stackoverflow.com/questions/63649179/how-to-create-playload-in-createasyncthunk-when-using-axios

The fix for this is to pass the data from the createAsyncThunk and not the axios response. While I could not test this fix in your code (as I don't have the mock api you used) I believe this pull request will fix it.

Thanks Carl